### PR TITLE
Word change

### DIFF
--- a/citizen_code_of_conduct.md
+++ b/citizen_code_of_conduct.md
@@ -36,7 +36,7 @@ The following behaviors are considered harassment and are unacceptable within ou
   * Posting or displaying sexually explicit or violent material.
   * Posting or threatening to post other people's personally identifying information ("doxing").
   * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
-  * Inappropriate photography or recording.
+  * Unwelcome photography or recording.
   * Inappropriate physical contact. You should have someone's consent before touching them.
   * Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
   * Deliberate intimidation, stalking or following (online or in person).


### PR DESCRIPTION
Suggest change of word from "inappropriate" to "unwelcome" in "Inappropriate photography or recording." I believe this bullet point is meant to describe when taking a photograph (versus sharing a photograph) should not be done. That should be cases where it is "unwelcome" by the subject, not whether or not the image itself would be offensive in some way.